### PR TITLE
Add ability to filter events by data source

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,14 +1,25 @@
 'use client';
+import { useState } from 'react';
 import dynamic from 'next/dynamic';
 
 const Calendar = dynamic(() => import('@/components/Calendar'), { ssr: false });
 import EventFilter from '@/components/EventFilter';
 
 const CalendarPage = () => {
+  const [sourceFilters, setSourceFilters] = useState<string[]>([
+    'Ellettsville Branch (MCPL)',
+    'Southwest Branch (MCPL)',
+    'Downtown Library (MCPL)',
+    'VisitBloomington',
+  ]);
+  const handleFilterChange = (selectedSources: string[]) => {
+    setSourceFilters(selectedSources);
+  };
+
   return (
     <div className="flex min-h-screen flex-col">
-      <EventFilter />
-      <Calendar />
+      <EventFilter onFilterChange={handleFilterChange} />
+      <Calendar sourceFilters={sourceFilters} />
     </div>
   );
 };

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -2,13 +2,13 @@
 import dynamic from 'next/dynamic';
 
 const Calendar = dynamic(() => import('@/components/Calendar'), { ssr: false });
+import EventFilter from '@/components/EventFilter';
 
 const CalendarPage = () => {
   return (
     <div className="flex min-h-screen flex-col">
+      <EventFilter />
       <Calendar />
-
-      {/* <footer className="flex flex-wrap items-center justify-center gap-6 bg-gray-800 p-4"></footer> */}
     </div>
   );
 };

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,17 +1,13 @@
 'use client';
 import { useState } from 'react';
+import { EventSource } from '@/components/EventFilter';
 import dynamic from 'next/dynamic';
 
 const Calendar = dynamic(() => import('@/components/Calendar'), { ssr: false });
 import EventFilter from '@/components/EventFilter';
 
 const CalendarPage = () => {
-  const [sourceFilters, setSourceFilters] = useState<string[]>([
-    'Ellettsville Branch (MCPL)',
-    'Southwest Branch (MCPL)',
-    'Downtown Library (MCPL)',
-    'VisitBloomington',
-  ]);
+  const [sourceFilters, setSourceFilters] = useState<string[]>(Object.values(EventSource));
   const handleFilterChange = (selectedSources: string[]) => {
     setSourceFilters(selectedSources);
   };

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,11 +1,15 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, FC } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import dayGridView from '@fullcalendar/daygrid';
 import listMonth from '@fullcalendar/list';
 import { useFetchEvents } from '@/hooks/useFetchEvents';
 
-const Calendar = () => {
+interface CalendarProps {
+  sourceFilters: string[];
+}
+
+const Calendar: FC<CalendarProps> = ({ sourceFilters = [] }) => {
   const { events, error } = useFetchEvents();
   const [calendarView, setCalendarView] = useState(
     window.innerWidth < 768 ? 'listMonth' : 'dayGridMonth',
@@ -34,12 +38,16 @@ const Calendar = () => {
     return <div>Failed to fetch events: {error.message}</div>;
   }
 
+  const filteredEvents = (events || []).filter((event) => {
+    return sourceFilters.includes(event.source);
+  });
+
   return (
     <div className="h-full">
       <FullCalendar
         plugins={[dayGridView, listMonth]}
         initialView={calendarView}
-        events={events}
+        events={filteredEvents}
         headerToolbar={{
           left: 'prev,next today',
           center: 'title',

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -5,7 +5,12 @@ interface EventFilterProps {
 }
 
 const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
-  const [selectedSources, setSelectedSources] = useState<string[]>([]);
+  const [selectedSources, setSelectedSources] = useState<string[]>([
+    'Ellettsville Branch (MCPL)',
+    'Southwest Branch (MCPL)',
+    'Downtown Library (MCPL)',
+    'VisitBloomington',
+  ]);
 
   const handleSourceChange = (source: string) => {
     const currentlySelectedSources = selectedSources.includes(source)
@@ -17,8 +22,8 @@ const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
 
   const sources = [
     'Ellettsville Branch (MCPL)',
-    'South West Branch (MCPL)',
-    'Downtown Library',
+    'Southwest Branch (MCPL)',
+    'Downtown Library (MCPL)',
     'VisitBloomington',
   ];
   return (

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -1,22 +1,28 @@
 import { FC } from 'react';
 
 const EventFilter: FC = () => {
+  const sources = [
+    'Ellettsville Branch (MCPL)',
+    'South West Branch (MCPL)',
+    'Downtown Library',
+    'VisitBloomington',
+  ];
   return (
     <div className="flex space-x-4 p-4">
       <div>
-        <h3>Filter by Source</h3>
-        <label className="flex items-center space-x-2">
-          <input type="checkbox" />
-          <span>Source 1</span>
-        </label>
-        <label className="flex items-center space-x-2">
-          <input type="checkbox" />
-          <span>Source 2</span>
-        </label>
-        <label className="flex items-center space-x-2">
-          <input type="checkbox" />
-          <span>Source 3</span>
-        </label>
+        <div>
+          <h3>Filter by Source</h3>
+        </div>
+        <div className="flex">
+          {sources.map((source) => {
+            return (
+              <label key={source} className="mx-2 flex items-center space-x-4">
+                <input type="checkbox" value={source} />
+                <span>{source}</span>
+              </label>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -30,7 +30,7 @@ const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
         <div>
           <h3 className="text-lg md:text-xl">Filter by Source</h3>
         </div>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {sources.map((source) => {
             return (
               <label key={source} className="mx-2 flex items-center space-x-4">

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -1,0 +1,25 @@
+import { FC } from 'react';
+
+const EventFilter: FC = () => {
+  return (
+    <div className="flex space-x-4 p-4">
+      <div>
+        <h3>Filter by Source</h3>
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" />
+          <span>Source 1</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" />
+          <span>Source 2</span>
+        </label>
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" />
+          <span>Source 3</span>
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default EventFilter;

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -4,13 +4,15 @@ interface EventFilterProps {
   onFilterChange: (selectedSources: string[]) => void;
 }
 
+export enum EventSource {
+  ELLETTSVILLE = 'Ellettsville Branch (MCPL)',
+  SOUTHWEST = 'Southwest Branch (MCPL)',
+  DOWNTOWN = 'Downtown Library (MCPL)',
+  VISIT_BLOOMINGTON = 'VisitBloomington',
+}
+
 const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
-  const [selectedSources, setSelectedSources] = useState<string[]>([
-    'Ellettsville Branch (MCPL)',
-    'Southwest Branch (MCPL)',
-    'Downtown Library (MCPL)',
-    'VisitBloomington',
-  ]);
+  const [selectedSources, setSelectedSources] = useState<string[]>(Object.values(EventSource));
 
   const handleSourceChange = (source: string) => {
     const currentlySelectedSources = selectedSources.includes(source)
@@ -20,12 +22,8 @@ const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
     onFilterChange(currentlySelectedSources);
   };
 
-  const sources = [
-    'Ellettsville Branch (MCPL)',
-    'Southwest Branch (MCPL)',
-    'Downtown Library (MCPL)',
-    'VisitBloomington',
-  ];
+  const sources = Object.values(EventSource);
+
   return (
     <div className="flex flex-col p-4 md:flex-row md:space-x-4">
       <div>

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -27,12 +27,12 @@ const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
     'VisitBloomington',
   ];
   return (
-    <div className="flex space-x-4 p-4">
+    <div className="flex flex-col p-4 md:flex-row md:space-x-4">
       <div>
         <div>
-          <h3>Filter by Source</h3>
+          <h3 className="text-lg md:text-xl">Filter by Source</h3>
         </div>
-        <div className="flex">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           {sources.map((source) => {
             return (
               <label key={source} className="mx-2 flex items-center space-x-4">
@@ -42,7 +42,7 @@ const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
                   checked={selectedSources.includes(source)}
                   onChange={() => handleSourceChange(source)}
                 />
-                <span>{source}</span>
+                <span className="text-sm md:text-base">{source}</span>
               </label>
             );
           })}

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -1,6 +1,20 @@
-import { FC } from 'react';
+import { useState, FC } from 'react';
 
-const EventFilter: FC = () => {
+interface EventFilterProps {
+  onFilterChange: (selectedSources: string[]) => void;
+}
+
+const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
+  const [selectedSources, setSelectedSources] = useState<string[]>([]);
+
+  const handleSourceChange = (source: string) => {
+    const currentlySelectedSources = selectedSources.includes(source)
+      ? selectedSources.filter((selectedSource) => selectedSource !== source)
+      : [...selectedSources, source];
+    setSelectedSources(currentlySelectedSources);
+    onFilterChange(currentlySelectedSources);
+  };
+
   const sources = [
     'Ellettsville Branch (MCPL)',
     'South West Branch (MCPL)',
@@ -17,7 +31,12 @@ const EventFilter: FC = () => {
           {sources.map((source) => {
             return (
               <label key={source} className="mx-2 flex items-center space-x-4">
-                <input type="checkbox" value={source} />
+                <input
+                  type="checkbox"
+                  value={source}
+                  checked={selectedSources.includes(source)}
+                  onChange={() => handleSourceChange(source)}
+                />
                 <span>{source}</span>
               </label>
             );

--- a/src/hooks/useFetchEvents.ts
+++ b/src/hooks/useFetchEvents.ts
@@ -9,6 +9,7 @@ interface McplEvent {
   description: string;
   color?: string;
   url: string;
+  source: string;
 }
 
 export const useFetchEvents = () => {

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,4 +1,5 @@
 import { toZonedTime, format } from 'date-fns-tz';
+import { EventSource } from '@/components/EventFilter';
 
 interface McplEvent {
   title: string;
@@ -26,11 +27,11 @@ interface VisitBloomEvent {
 const getMcplLocation = (locationId: string) => {
   switch (locationId) {
     case '3696':
-      return { location: 'Ellettsville Branch (MCPL)', color: 'green' };
+      return { location: EventSource.ELLETTSVILLE, color: 'green' };
     case '3697':
-      return { location: 'Southwest Branch (MCPL)', color: 'purple' };
+      return { location: EventSource.SOUTHWEST, color: 'purple' };
     case '3648':
-      return { location: 'Downtown Library (MCPL)', color: '#3788d8' };
+      return { location: EventSource.DOWNTOWN, color: '#3788d8' };
     default:
       return { location: 'Unknown Location', color: 'gray' };
   }

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -26,11 +26,11 @@ interface VisitBloomEvent {
 const getMcplLocation = (locationId: string) => {
   switch (locationId) {
     case '3696':
-      return { location: 'Ellettsville Branch', color: 'green' };
+      return { location: 'Ellettsville Branch (MCPL)', color: 'green' };
     case '3697':
-      return { location: 'South West Branch', color: 'purple' };
+      return { location: 'Southwest Branch (MCPL)', color: 'purple' };
     case '3648':
-      return { location: 'Downtown Library', color: '#3788d8' };
+      return { location: 'Downtown Library (MCPL)', color: '#3788d8' };
     default:
       return { location: 'Unknown Location', color: 'gray' };
   }
@@ -50,6 +50,7 @@ export const mcplFormatter = (data: McplEvent[]) => {
       description: event.description,
       url: normalizeUrl(event.url),
       location,
+      source: location,
       color,
     };
   });
@@ -72,6 +73,7 @@ export const visitBloomFormatter = (data: VisitBloomEvent[]) => {
         .replace(/&amp;/g, '&'),
       color,
       url: `${baseURL}${event.url}`,
+      source: 'VisitBloomington',
     };
   });
 };


### PR DESCRIPTION
Users are now able to filter out events based on the source that the data came from.  At this time those sources are `Ellettsville Branch (MCPL)`, `Southwest Branch (MCPL)`, `Downtown Library (MCPL)`, `VisitBloomington`