### PR TITLE
Move source filter state to react context

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,8 @@
-import Calendar from '@/components/Calendar';
+'use client';
+import dynamic from 'next/dynamic';
 import EventFilter from '@/components/EventFilter';
 
+const Calendar = dynamic(() => import('@/components/Calendar'), { ssr: false });
 const CalendarPage = () => {
   return (
     <div className="flex min-h-screen flex-col">

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,21 +1,11 @@
-'use client';
-import { useState } from 'react';
-import { EventSource } from '@/components/EventFilter';
-import dynamic from 'next/dynamic';
-
-const Calendar = dynamic(() => import('@/components/Calendar'), { ssr: false });
+import Calendar from '@/components/Calendar';
 import EventFilter from '@/components/EventFilter';
 
 const CalendarPage = () => {
-  const [sourceFilters, setSourceFilters] = useState<string[]>(Object.values(EventSource));
-  const handleFilterChange = (selectedSources: string[]) => {
-    setSourceFilters(selectedSources);
-  };
-
   return (
     <div className="flex min-h-screen flex-col">
-      <EventFilter onFilterChange={handleFilterChange} />
-      <Calendar sourceFilters={sourceFilters} />
+      <EventFilter />
+      <Calendar />
     </div>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import './globals.css';
-import { EventSourceProvider } from '@/context/EventSourceContext';
 import Navigation from '@/components/Navigation';
+import { EventSourceProvider } from '@/context/EventSourceContext';
+import './globals.css';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
+import { EventSourceProvider } from '@/context/EventSourceContext';
 import Navigation from '@/components/Navigation';
 
 const geistSans = Geist({
@@ -33,8 +34,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Navigation />
-        {children}
+        <EventSourceProvider>
+          <Navigation />
+          {children}
+        </EventSourceProvider>
       </body>
     </html>
   );

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -4,13 +4,11 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridView from '@fullcalendar/daygrid';
 import listMonth from '@fullcalendar/list';
 import { useFetchEvents } from '@/hooks/useFetchEvents';
+import { useEventSourceContext } from '@/context/EventSourceContext';
 
-interface CalendarProps {
-  sourceFilters: string[];
-}
-
-const Calendar: FC<CalendarProps> = ({ sourceFilters = [] }) => {
+const Calendar: FC<CalendarProps> = () => {
   const { events, error } = useFetchEvents();
+  const { selectedSources } = useEventSourceContext();
   const [calendarView, setCalendarView] = useState(
     window.innerWidth < 768 ? 'listMonth' : 'dayGridMonth',
   );
@@ -39,7 +37,7 @@ const Calendar: FC<CalendarProps> = ({ sourceFilters = [] }) => {
   }
 
   const filteredEvents = (events || []).filter((event) => {
-    return sourceFilters.includes(event.source);
+    return selectedSources.includes(event.source);
   });
 
   return (

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -6,7 +6,7 @@ import listMonth from '@fullcalendar/list';
 import { useFetchEvents } from '@/hooks/useFetchEvents';
 import { useEventSourceContext } from '@/context/EventSourceContext';
 
-const Calendar: FC<CalendarProps> = () => {
+const Calendar: FC = () => {
   const { events, error } = useFetchEvents();
   const { selectedSources } = useEventSourceContext();
   const [calendarView, setCalendarView] = useState(

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -1,26 +1,9 @@
-import { useState, FC } from 'react';
+'use client';
+import { FC } from 'react';
+import { useEventSourceContext, EventSource } from '@/context/EventSourceContext';
 
-interface EventFilterProps {
-  onFilterChange: (selectedSources: string[]) => void;
-}
-
-export enum EventSource {
-  ELLETTSVILLE = 'Ellettsville Branch (MCPL)',
-  SOUTHWEST = 'Southwest Branch (MCPL)',
-  DOWNTOWN = 'Downtown Library (MCPL)',
-  VISIT_BLOOMINGTON = 'VisitBloomington',
-}
-
-const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
-  const [selectedSources, setSelectedSources] = useState<string[]>(Object.values(EventSource));
-
-  const handleSourceChange = (source: string) => {
-    const currentlySelectedSources = selectedSources.includes(source)
-      ? selectedSources.filter((selectedSource) => selectedSource !== source)
-      : [...selectedSources, source];
-    setSelectedSources(currentlySelectedSources);
-    onFilterChange(currentlySelectedSources);
-  };
+const EventFilter: FC = () => {
+  const { selectedSources, setStateSelectedSources } = useEventSourceContext();
 
   const sources = Object.values(EventSource);
 
@@ -38,7 +21,7 @@ const EventFilter: FC<EventFilterProps> = ({ onFilterChange }) => {
                   type="checkbox"
                   value={source}
                   checked={selectedSources.includes(source)}
-                  onChange={() => handleSourceChange(source)}
+                  onChange={() => setStateSelectedSources(source)}
                 />
                 <span className="text-sm md:text-base">{source}</span>
               </label>

--- a/src/components/EventFilter.tsx
+++ b/src/components/EventFilter.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 import { useEventSourceContext, EventSource } from '@/context/EventSourceContext';
 
 const EventFilter: FC = () => {
-  const { selectedSources, setStateSelectedSources } = useEventSourceContext();
+  const { selectedSources, setStateSelectedSource } = useEventSourceContext();
 
   const sources = Object.values(EventSource);
 
@@ -21,7 +21,7 @@ const EventFilter: FC = () => {
                   type="checkbox"
                   value={source}
                   checked={selectedSources.includes(source)}
-                  onChange={() => setStateSelectedSources(source)}
+                  onChange={() => setStateSelectedSource(source)}
                 />
                 <span className="text-sm md:text-base">{source}</span>
               </label>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 
 const Navigation = () => {
   const [menuOpen, setMenuOpen] = useState(false);
+
   const pathname = usePathname();
 
   const links = new Map().set('Home', '/').set('Calendar', '/calendar');

--- a/src/context/EventSourceContext.tsx
+++ b/src/context/EventSourceContext.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export enum EventSource {
+  ELLETTSVILLE = 'Ellettsville Branch (MCPL)',
+  SOUTHWEST = 'Southwest Branch (MCPL)',
+  DOWNTOWN = 'Downtown Library (MCPL)',
+  VISIT_BLOOMINGTON = 'VisitBloomington',
+}
+
+interface EventSourceContextType {
+  selectedSources: string[];
+  setSelectedSources: (source: string[]) => void;
+}
+
+interface EventSourceProviderProps {
+  children: ReactNode;
+}
+
+const EventSourceContext = createContext<EventSourceContextType | undefined>(undefined);
+
+export const EventSourceProvider = ({ children }: EventSourceProviderProps) => {
+  const [selectedSources, setSelectedSources] = useState<string[]>(Object.values(EventSource));
+
+  const setStateSelectedSources = (source: string) => {
+    setSelectedSources((previousSelectedSources) =>
+      previousSelectedSources.includes(source)
+        ? previousSelectedSources.filter((selectedSource) => selectedSource !== source)
+        : [...previousSelectedSources, source],
+    );
+  };
+
+  return (
+    <EventSourceContext.Provider value={{ selectedSources, setStateSelectedSources }}>
+      {children}
+    </EventSourceContext.Provider>
+  );
+};
+
+export const useEventSourceContext = () => {
+  const context = useContext(EventSourceContext);
+
+  if (!context) {
+    throw new Error('useEventSourceContext must be used within an EventSourceProvider');
+  }
+
+  return context;
+};

--- a/src/context/EventSourceContext.tsx
+++ b/src/context/EventSourceContext.tsx
@@ -10,7 +10,7 @@ export enum EventSource {
 
 interface EventSourceContextType {
   selectedSources: string[];
-  setStateSelectedSources: (source: string[]) => void;
+  setStateSelectedSource: (source: string) => void;
 }
 
 interface EventSourceProviderProps {
@@ -22,7 +22,7 @@ const EventSourceContext = createContext<EventSourceContextType | undefined>(und
 export const EventSourceProvider = ({ children }: EventSourceProviderProps) => {
   const [selectedSources, setSelectedSources] = useState<string[]>(Object.values(EventSource));
 
-  const setStateSelectedSources = (source: string) => {
+  const setStateSelectedSource = (source: string) => {
     setSelectedSources((previousSelectedSources) =>
       previousSelectedSources.includes(source)
         ? previousSelectedSources.filter((selectedSource) => selectedSource !== source)
@@ -31,7 +31,7 @@ export const EventSourceProvider = ({ children }: EventSourceProviderProps) => {
   };
 
   return (
-    <EventSourceContext.Provider value={{ selectedSources, setStateSelectedSources }}>
+    <EventSourceContext.Provider value={{ selectedSources, setStateSelectedSource }}>
       {children}
     </EventSourceContext.Provider>
   );

--- a/src/context/EventSourceContext.tsx
+++ b/src/context/EventSourceContext.tsx
@@ -10,7 +10,7 @@ export enum EventSource {
 
 interface EventSourceContextType {
   selectedSources: string[];
-  setSelectedSources: (source: string[]) => void;
+  setStateSelectedSources: (source: string[]) => void;
 }
 
 interface EventSourceProviderProps {

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,5 +1,5 @@
 import { toZonedTime, format } from 'date-fns-tz';
-import { EventSource } from '@/components/EventFilter';
+import { EventSource } from '@/context/EventSourceContext';
 
 interface McplEvent {
   title: string;


### PR DESCRIPTION
This is in anticipation of a future migration to MUI.  State will be more difficult to move and this would allow for the state to be global and more flexible to future changes.