### PR TITLE
caching on vercels edge network

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,19 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/api/all-events',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 's-maxage=60, stale-while-revalidate',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
To improve performance when fetching from `api/all-events` endpoint.  Caching has been set to take advantage of vercel's edge network
